### PR TITLE
Fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !lang
 !lib
 !pages
+!public
 !scripts
 !server
 !static


### PR DESCRIPTION
Include `public` in the Docker container so that the build is successful.